### PR TITLE
Bump podspec stripe_version

### DIFF
--- a/stripe-react-native-apple-pay.podspec
+++ b/stripe-react-native-apple-pay.podspec
@@ -3,7 +3,7 @@ require "json"
 package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 # Keep stripe_version in sync with https://github.com/stripe/stripe-identity-react-native/blob/main/stripe-identity-react-native.podspec
-stripe_version = '~> 23.8.0'
+stripe_version = '~> 23.30.0'
 
 Pod::Spec.new do |s|
   s.name         = "stripe-react-native-apple-pay"


### PR DESCRIPTION
Bump podspec stripe_version in line with stripe-react-native 0.39.0 which is last version compatible with React Native Old Architecture